### PR TITLE
CBPeripheralStateDisconnecting is not a valid enum

### DIFF
--- a/bluetooth.ios.js
+++ b/bluetooth.ios.js
@@ -337,8 +337,6 @@ Bluetooth._getState = function(stateId) {
     return 'connecting';
   } else if (stateId == CBPeripheralStateConnected) {
     return 'connected';
-  } else if (stateId == CBPeripheralStateDisconnecting) {
-    return 'disconnecting';
   } else if (stateId == CBPeripheralStateDisconnected) {
     return 'disconnected';
   } else {


### PR DESCRIPTION
Upon testing the plugin against a BLE-to-Serial Adapter, I received a javascript error that the variable CBPeripheralStateDisconnecting did not exist. Based on the iOS documentation, this does not appear to be a valid enum. I have removed it from the if statement. The documentation is at:
https://developer.apple.com/library/prerelease/ios/documentation/CoreBluetooth/Reference/CBPeripheral_Class/index.html#//apple_ref/c/tdef/CBPeripheralState