### PR TITLE
Added setCharacteristicLogging to reduce console.log logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,12 @@ bluetooth.stopNotifying({
 });
 ```
 
+### setCharacteristicLogging
+The app using bluetooth can generate many console.log messages - one for each characteristic read, write, change.
+This can be reduced by calling `bluetooth.setCharacteristicLogging(false)`.
+
 ## Changelog
+* 1.1.5  Added setCharacteristicLogging function to reduce logging
 * 1.1.4  TypeScript fix and TS definition fix in package.json
 * 1.1.3  TypeScript fix
 * 1.1.2  Better Android M compatibility

--- a/bluetooth-common.js
+++ b/bluetooth-common.js
@@ -1,6 +1,8 @@
 require('./base64');
 
-var Bluetooth = {};
+var Bluetooth = {
+  characteristicLogging: true
+};
 
 Bluetooth.requestCoarseLocationPermission = function () {
   return new Promise(function (resolve) {
@@ -24,5 +26,9 @@ Bluetooth._base64ToArrayBuffer = function (b64) {
   };
   return stringToArrayBuffer(atob(b64));
 };
+
+Bluetooth.setCharacteristicLogging = function (enable) {
+  Bluetooth.characteristicLogging = enable;
+}
 
 module.exports = Bluetooth;

--- a/bluetooth.android.js
+++ b/bluetooth.android.js
@@ -242,7 +242,8 @@ Bluetooth._MyGattCallback = android.bluetooth.BluetoothGattCallback.extend({
   },
 
   onCharacteristicRead: function(bluetoothGatt, bluetoothGattCharacteristic, status) {
-    console.log("------- _MyGattCallback.onCharacteristicRead");
+    if(Bluetooth.characteristicLogging)
+      console.log("------- _MyGattCallback.onCharacteristicRead");
 
     var device = bluetoothGatt.getDevice();
     var stateObject = Bluetooth._connections[device.getAddress()];
@@ -262,7 +263,8 @@ Bluetooth._MyGattCallback = android.bluetooth.BluetoothGattCallback.extend({
   },
 
   onCharacteristicChanged: function(bluetoothGatt, bluetoothGattCharacteristic) {
-    console.log("------- _MyGattCallback.onCharacteristicChanged");
+    if(Bluetooth.characteristicLogging)
+      console.log("------- _MyGattCallback.onCharacteristicChanged");
 
     var device = bluetoothGatt.getDevice();
     var stateObject = Bluetooth._connections[device.getAddress()];
@@ -282,7 +284,8 @@ Bluetooth._MyGattCallback = android.bluetooth.BluetoothGattCallback.extend({
   },
 
   onCharacteristicWrite: function(bluetoothGatt, bluetoothGattCharacteristic, status) {
-    console.log("------- _MyGattCallback.onCharacteristicWrite");
+    if(Bluetooth.characteristicLogging)
+      console.log("------- _MyGattCallback.onCharacteristicWrite");
 
     var device = bluetoothGatt.getDevice();
     var stateObject = Bluetooth._connections[device.getAddress()];
@@ -291,7 +294,8 @@ Bluetooth._MyGattCallback = android.bluetooth.BluetoothGattCallback.extend({
       return;
     }
 
-    console.log(bluetoothGattCharacteristic);
+    if(Bluetooth.characteristicLogging)
+      console.log(bluetoothGattCharacteristic);
 
     if (stateObject.onWritePromise) {
       stateObject.onWritePromise({

--- a/bluetooth.d.ts
+++ b/bluetooth.d.ts
@@ -170,6 +170,12 @@ declare module "nativescript-bluetooth" {
      * Required for Android 6+ to be able to scan for peripherals in the background.
      */
     export function requestCoarseLocationPermission(): Promise<any>;
+    
+    /**
+     * Can be used to reduce the console.log messaging for characteristic read, write, change operations
+     * @param enable Set to false to reduce console.log messages
+     */
+    export function setCharacteristicLogging(enable: boolean);
 
     export function startScanning(options: StartScanningOptions): Promise<any>;
     export function stopScanning(): Promise<any>;

--- a/bluetooth.ios.js
+++ b/bluetooth.ios.js
@@ -723,7 +723,9 @@ Bluetooth.writeWithoutResponse = function (arg) {
       }
 
       var valueEncoded = Bluetooth._encodeValue(arg.value);
-      console.log("Attempting to write (encoded): " + valueEncoded);
+      
+      if(Bluetooth.extensiveLogging)
+        console.log("Attempting to write (encoded): " + valueEncoded);
       
       wrapper.peripheral.writeValueForCharacteristicType(
         valueEncoded,

--- a/bluetooth.ios.js
+++ b/bluetooth.ios.js
@@ -724,7 +724,7 @@ Bluetooth.writeWithoutResponse = function (arg) {
 
       var valueEncoded = Bluetooth._encodeValue(arg.value);
       
-      if(Bluetooth.extensiveLogging)
+      if (Bluetooth.characteristicLogging)
         console.log("Attempting to write (encoded): " + valueEncoded);
       
       wrapper.peripheral.writeValueForCharacteristicType(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-bluetooth",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description" : "Connect to and interact with Bluetooth LE peripherals",
   "main" : "bluetooth",
   "typings": "bluetooth.d.ts",


### PR DESCRIPTION
When performing 50 BLE write operations per second the terminal can become a bit overwhelming and unusable for logging other events.
Adding setCharacteristicLogging function aims at reducing the logging for read, write and change characteristic operations.