### PR TITLE
Fix: to allow using Uint8Array for the write functions

### DIFF
--- a/bluetooth.android.js
+++ b/bluetooth.android.js
@@ -649,14 +649,16 @@ Bluetooth.read = function (arg) {
 
 // val must be a Uint8Array or Uint16Array or a string like '0x01' or '0x007F' or '0x01,0x02', or '0x007F,'0x006F''
 Bluetooth._encodeValue = function(val) {
+  var parts = val;
   // if it's not a string assume it's a byte array already
-  if (typeof val != 'string') {
-    return val;
+  if (typeof val === 'string') {
+    parts = val.split(',');
+
+    if (parts[0].indexOf('x') == -1) {
+      return null;
+    }
   }
-  var parts = val.split(',');
-  if (parts[0].indexOf('x') == -1) {
-    return null;
-  }
+
   var result = Array.create("byte", parts.length);
 
   for (var i=0; i<parts.length; i++) {


### PR DESCRIPTION
This fix takes the items of Uint8Array through the same parsing process as the string tokens.

I've tested it on Android 6.0.1. It works fine with Uint8Array

It is related to issue #36
