### PR TITLE
Add "continuous" scan flag to control whether onDiscovered should be …

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,11 @@ declare module "nativescript-bluetooth" {
      * This callback is invoked when a peripheral is found.
      */
     onDiscovered: (data: Peripheral) => void;
+
+    /**
+     * If set to true, onDiscovered is called not just once per peripheral but for each advertising packet
+     */
+    continuous?: boolean;
   }
 
   /**


### PR DESCRIPTION
I have added the optional `continuous` flag to `StartScanningOptions`. If set to true, the `onDiscovered` function is called for each advertising packet and not just once.

This is based on the 1.3.0 code. As soon as the master branch is released, I can add it there too.