### PR TITLE
fix logical clean up of connected devices on start scanning

### DIFF
--- a/src/android/android_main.ts
+++ b/src/android/android_main.ts
@@ -191,7 +191,11 @@ export class Bluetooth extends BluetoothCommon {
         }
 
         const onPermissionGranted = () => {
-          this.connections = {};
+          for (var key in this.connections) {
+            if (this.connections[key] === null || this.connections[key].state === 'disconnected') {
+              delete this.connections[key];
+            }
+          }
 
           const serviceUUIDs = arg.serviceUUIDs || [];
           const uuids = [];

--- a/src/ios/ios_main.ts
+++ b/src/ios/ios_main.ts
@@ -77,7 +77,15 @@ export class Bluetooth extends BluetoothCommon {
           return;
         }
 
-        this._peripheralArray = NSMutableArray.new();
+        const connectedPeripherals = NSMutableArray.new();
+        for (let i = 0; i < this._peripheralArray.count; i++) {
+          const peripheral = this._peripheralArray.objectAtIndex(i);
+          if (peripheral !== null && this._getState(peripheral.state) === 'connected') {
+            connectedPeripherals.addObject(peripheral);
+          }
+        }
+
+        this._peripheralArray = connectedPeripherals;
         this._onDiscovered = arg.onDiscovered;
         const serviceUUIDs = arg.serviceUUIDs || [];
 


### PR DESCRIPTION
Hi,
first of all I want to thank you for your precious work.
I made this pull request because for a project I work on I have to connect up to two devices. So I fetch every x minutes and start scanning to find a device to connect. I found that both in android and iOS library every time you start scanning for devices you initialize the connected peripherals array. So I ended up with the smartphone SO connected but I lost the reference in the nativescript wrapper.
If you need more details I can reply to your questions.